### PR TITLE
Make Let take a declaration.

### DIFF
--- a/examples/evenodd.simala
+++ b/examples/evenodd.simala
@@ -1,0 +1,9 @@
+-- The unforuntately quite complicated way in which we have to
+-- encode mutually recursive definitions right now. It would be
+-- better if recursive declarations would work for non-functions.
+--
+let rec evenodd = fun (unused) =>
+  { even = fun (x) => x == 0 || evenodd(unused).odd(x - 1)
+  , odd  = fun (x) => x == 1 || evenodd(unused).even(x - 1)
+  }
+in evenodd('irrelevant).even(20)

--- a/examples/evenodd.simala
+++ b/examples/evenodd.simala
@@ -1,4 +1,4 @@
--- The unforuntately quite complicated way in which we have to
+-- The unfortunately quite complicated way in which we have to
 -- encode mutually recursive definitions right now. It would be
 -- better if recursive declarations would work for non-functions.
 --

--- a/examples/mapfilter.simala
+++ b/examples/mapfilter.simala
@@ -1,20 +1,13 @@
-let opaque id =
+let
 
-    fun (x) => x in
+  opaque id = fun (x) => x;
+  opaque cons = fun (x) => fun (xs) => x : xs;
+  opaque map = fun (f, xs) =>
+    foldr (fun (x, r) => f(x) : r, [], xs);
+  opaque filter = fun (p, xs) =>
+    foldr (fun (x, r) => (if p(x) then cons(x) else id)(r), [], xs)
 
-let opaque cons =
-
-    fun (x) => fun (xs) => x : xs in
-
-let opaque map =
-  
-    fun (f, xs) =>
-    foldr (fun (x, r) => f(x) : r, [], xs) in
-
-let opaque filter =
-
-    fun (p, xs) =>
-    foldr (fun (x, r) => (if p(x) then cons(x) else id)(r), [], xs) in
+in
 
   filter
     ( fun (x) => x % 2 == 0,

--- a/examples/take.simala
+++ b/examples/take.simala
@@ -1,4 +1,4 @@
-letrec take =
+let rec take =
 
   fun (n, xs) =>
 

--- a/src/Simala/Expr/Evaluator.hs
+++ b/src/Simala/Expr/Evaluator.hs
@@ -65,14 +65,10 @@ eval' (App f args)        = do
 eval' (Fun t ns body)     = do
   env <- getEnv
   pure (VClosure (MkClosure t ns body env))
-eval' (Let t n e1 e2)     = do
-  env' <- evalDecl (NonRec t n e1)
+eval' (Let d e)     = do
+  env' <- evalDecl d
   env <- getEnv
-  withEnv (extendEnv env env') (eval e2)
-eval' (Letrec t n e1 e2)  = do
-  env'' <- evalDecl (Rec t n e1)
-  env <- getEnv
-  withEnv (extendEnv env env'') (eval e2)
+  withEnv (extendEnv env env') (eval e)
 
 evalDecl :: Decl -> Eval Env
 evalDecl (NonRec t n e) = do

--- a/src/Simala/Expr/Parser.hs
+++ b/src/Simala/Expr/Parser.hs
@@ -143,8 +143,7 @@ builtin2 f e1 e2 = Builtin f [e1, e2]
 
 baseExpr :: Parser Expr
 baseExpr =
-      Let  <$ keyword "let" <*> transparency <*> name <* symbol "=" <*> expr <* keyword "in" <*> expr
-  <|> Letrec <$ keyword "letrec" <*> transparency <*> name <* symbol "=" <*> expr <* keyword "in" <*> expr
+      mkLet <$ keyword "let" <*> decls <* keyword "in" <*> expr
   <|> Fun <$ keyword "fun" <*> transparency <*> argsOf name <* symbol "=>" <*> expr
   <|> mkIfThenElse <$ keyword "if" <*> expr <* keyword "then" <*> expr <* keyword "else" <*> expr
   <|> List <$> between (symbol "[") (symbol "]") (sepBy expr (symbol ","))
@@ -174,9 +173,6 @@ transparency =
     (   Transparent <$ keyword "transparent"
     <|> Opaque      <$ keyword "opaque"
     )
-
-mkIfThenElse :: Expr -> Expr -> Expr -> Expr
-mkIfThenElse c t e = Builtin IfThenElse [c, t, e]
 
 argsOf :: Parser a -> Parser [a]
 argsOf p = between (symbol "(") (symbol ")") (sepBy p (symbol ","))

--- a/src/Simala/Expr/Render.hs
+++ b/src/Simala/Expr/Render.hs
@@ -45,8 +45,7 @@ instance Render Expr where
   renderAtPrio _ (Record r)         = renderRow " = " r
   renderAtPrio p (Project e n)      = parensIf (p > 9) (renderAtPrio 9 e <> "." <> render n)
   renderAtPrio p (Fun t args e)     = parensIf (p > 0) ("fun" <> renderTransparency t <> " " <> renderArgs args <> " => " <> render e)
-  renderAtPrio p (Let t x e1 e2)    = parensIf (p > 0) ("let" <> renderTransparency t <> " " <> render x <> " = " <> render e1 <> " in " <> render e2)
-  renderAtPrio p (Letrec t x e1 e2) = parensIf (p > 0) ("letrec" <> renderTransparency t <> " " <> render x <> " = " <> render e1 <> " in " <> render e2)
+  renderAtPrio p (Let d e)          = parensIf (p > 0) ("let" <> renderAtPrio 0 d <> " in " <> render e)
   renderAtPrio p (App e es)         = parensIf (p > 9) (renderAtPrio 9 e <> renderArgs es)
   renderAtPrio _ Undefined          = "undefined"
 

--- a/src/Simala/Expr/Type.hs
+++ b/src/Simala/Expr/Type.hs
@@ -5,7 +5,8 @@ import qualified Base.Map as Map
 
 type Name = Text
 
--- | Currently only for use in the repl.
+-- | Declarations are used in the repl, in declaration files,
+-- and in let expressions.
 --
 -- Mutually recursive operations are not directly possible right
 -- now and have to be simulated via records.
@@ -47,8 +48,7 @@ data Expr =
   | Record     (Row Expr)                  -- record construction
   | Project    Expr Name                   -- record projection
   | Fun        Transparency [Name] Expr    -- anonymous function
-  | Let        Transparency Name Expr Expr -- local declaration
-  | Letrec     Transparency Name Expr Expr -- local recursive declaration
+  | Let        Decl Expr                   -- possibly recursive let-binding
   | Undefined                              -- unclear
   deriving stock Show
 
@@ -177,3 +177,11 @@ singletonEnv n v = Map.singleton n v
 -- | Look up a name in an environment.
 lookupInEnv :: Name -> Env -> Maybe Val
 lookupInEnv = Map.lookup
+
+-- | Helper function to create an if-then-else construct.
+mkIfThenElse :: Expr -> Expr -> Expr -> Expr
+mkIfThenElse c t e = Builtin IfThenElse [c, t, e]
+
+-- | Helper function to create a nested let expression.
+mkLet :: [Decl] -> Expr -> Expr
+mkLet ds e = foldr Let e ds


### PR DESCRIPTION
This is a non-backwards-compatible syntax change, because "letrec" must now be written as "let rec". Additionally, it becomes possible in textual input syntax to write multiple declarations in a single let construct by separating them via semicolon. But this is just directly desugared into nested lets by the parser.