### PR TITLE
Add support for merging records

### DIFF
--- a/examples/record2.simala
+++ b/examples/record2.simala
@@ -1,0 +1,5 @@
+let a = { x = 2, y = 3 }
+in
+let b = { x = 'atom, z = 3 }
+in
+    merge(a, b)

--- a/src/Simala/Expr/Evaluator.hs
+++ b/src/Simala/Expr/Evaluator.hs
@@ -19,7 +19,7 @@ eval e = do
   when (t == Transparent) (exit v)
   pure v
 
--- | Evaluate an expression, but change the 
+-- | Evaluate an expression, but change the
 -- transparency level only for the inner part.
 --
 evalWithTransparency :: Transparency -> Name -> Expr -> Eval Val
@@ -262,6 +262,14 @@ evalBuiltin Case es = do
     (v : vs) -> do
       c <- (eval >=> expectFunction) e2
       evalClosureVal c [v, VList vs]
+evalBuiltin Merge es = do
+  (e1, e2) <- expectArity2 es
+  r1 <- (eval >=> expectRecord) e1
+  r2 <- (eval >=> expectRecord) e2
+  -- Right biased merging of records.
+  -- We could be smarter in the case of nested records.
+  let r = Map.toList $ Map.unionWith (\_ b -> b) (Map.fromList r1) (Map.fromList r2)
+  pure $ VRecord r
 
 doEvalTracing :: TraceMode -> Env -> Expr -> IO ()
 doEvalTracing tracing env e =

--- a/src/Simala/Expr/Parser.hs
+++ b/src/Simala/Expr/Parser.hs
@@ -215,6 +215,7 @@ builtins =
     , ("case", Case)
     , ("sum", Sum)
     , ("product", Product)
+    , ("merge", Merge)
     ]
 
 decl :: Parser Decl

--- a/src/Simala/Expr/Render.hs
+++ b/src/Simala/Expr/Render.hs
@@ -130,6 +130,7 @@ instance Render Builtin where
   render Foldr      = "foldr"
   render Foldl      = "foldl"
   render Case       = "case"
+  render Merge      = "merge"
 
 instance Render Lit where
   render :: Lit -> Text

--- a/src/Simala/Expr/Type.hs
+++ b/src/Simala/Expr/Type.hs
@@ -86,6 +86,7 @@ data Builtin =
   | Foldl      -- ^ left fold, arity 3
   | Foldr      -- ^ right fold, arity 3
   | Case       -- ^ case on lists, arity 3
+  | Merge      -- ^ Merge two records, arity 2
   deriving stock Show
 
 -- | A value.


### PR DESCRIPTION
Introduce a new built-in which allows merging two records into one. If a key occurs in both records, the merging is right-biased.

Example:

```
> merge({a = 1, b = 2}, {a = 'atom, c = 3})
{a = 'atom, b = 2, c = 3}
```

Name of the operator is subject to bikeshedding.