### PR TITLE
Relax recursive let.

### DIFF
--- a/examples/letrec.simala
+++ b/examples/letrec.simala
@@ -1,0 +1,12 @@
+rec x = 2; -- recursive value bindings should now just work
+y = 3; -- non-recursive ones as well
+rec z = z; -- this should crash / yield a blackhole
+#eval x;
+#eval y;
+#eval z;
+
+
+#eval
+  let rec x = 1
+  in let rec y = (let rec x = 10 in x)
+     in x + y * y


### PR DESCRIPTION
We could do much better, but for now we lift the restriction that recursive let only works for functions. For non-functions, any occurrence of the defined values will be a blackhole though.