### PR TITLE
Add a typeof builtin for run-time type checking.

### DIFF
--- a/src/Simala/Expr/Evaluator.hs
+++ b/src/Simala/Expr/Evaluator.hs
@@ -390,6 +390,21 @@ evalBuiltin Explode es = do
 evalBuiltin Append es = do
   (s1, s2) <- expect2Strings es
   pure $ VString (s1 <> s2)
+evalBuiltin TypeOf es = do
+  e <- expectArity1 es
+  v <- eval e
+  pure $ VAtom (atomFor (valTy v))
+
+atomFor :: ValTy -> Name
+atomFor TInt       = "int"
+atomFor TBool      = "bool"
+atomFor TString    = "string"
+atomFor TFrac      = "frac"
+atomFor TList      = "list"
+atomFor TRecord    = "record"
+atomFor TFun       = "fun"
+atomFor TAtom      = "atom"
+atomFor TBlackhole = "blackhole"
 
 doEvalDeclsTracing :: TraceMode -> Env -> [Decl] -> IO Env
 doEvalDeclsTracing tracing env ds =

--- a/src/Simala/Expr/Parser.hs
+++ b/src/Simala/Expr/Parser.hs
@@ -233,7 +233,7 @@ builtins =
     , ("ceiling", Ceiling)
     , ("fromInt", FromInt)
     , ("explode", Explode)
-    , ("typeof", TypeOf)
+    , ("typeOf", TypeOf)
     ]
 
 decl :: Parser Decl

--- a/src/Simala/Expr/Parser.hs
+++ b/src/Simala/Expr/Parser.hs
@@ -233,6 +233,7 @@ builtins =
     , ("ceiling", Ceiling)
     , ("fromInt", FromInt)
     , ("explode", Explode)
+    , ("typeof", TypeOf)
     ]
 
 decl :: Parser Decl

--- a/src/Simala/Expr/Render.hs
+++ b/src/Simala/Expr/Render.hs
@@ -139,7 +139,7 @@ instance Render Builtin where
   render FromInt    = "fromInt"
   render Explode    = "explode"
   render Append     = "append"
-  render TypeOf     = "typeof"
+  render TypeOf     = "typeOf"
 
 instance Render Lit where
   render :: Lit -> Text

--- a/src/Simala/Expr/Render.hs
+++ b/src/Simala/Expr/Render.hs
@@ -139,6 +139,7 @@ instance Render Builtin where
   render FromInt    = "fromInt"
   render Explode    = "explode"
   render Append     = "append"
+  render TypeOf     = "typeof"
 
 instance Render Lit where
   render :: Lit -> Text

--- a/src/Simala/Expr/Type.hs
+++ b/src/Simala/Expr/Type.hs
@@ -38,7 +38,7 @@ data ReplCommand =
   deriving stock Show
 
 data Expr =
-    Builtin    Builtin [Expr]              -- built-ins; the currently decide their own eval strategy, so can be used for control flow
+    Builtin    Builtin [Expr]              -- built-ins; they currently decide their own eval strategy, so can be used for control flow
   | Var        Name
   | Atom       Name                        -- for simulating enumeration types
   | Lit        Lit
@@ -95,6 +95,7 @@ data Builtin =
   | FromInt    -- ^ Convert an integer to a fractional, arity 1
   | Explode    -- ^ Explode a string into a list of single-character strings, arity 1
   | Append     -- ^ Append two strings, arity 2
+  | TypeOf     -- ^ run-time type checking, arity 1, returns an atom indicating the type
   deriving stock Show
 
 -- | A value.


### PR DESCRIPTION
I think if we actually need Simala as a source language or target language for untyped code, we may need this to be able to be defensive and robust.