### PR TITLE
evenodd.simala: Tweak so that it gives the right result for examples like `evenodd('irrelevant).even(3)` and `#eval evenodd('irrelevant).odd(2)`, instead of looping forever

### DIFF
--- a/examples/evenodd.simala
+++ b/examples/evenodd.simala
@@ -3,7 +3,7 @@
 -- better if recursive declarations would work for non-functions.
 --
 rec evenodd = fun (unused) =>
-  { even = fun (x) => x == 0 || evenodd(unused).odd(x - 1)
+  { even = fun (x) => x == 0 || not(evenodd(unused).odd(x))
   , odd  = fun (x) => x == 1 || evenodd(unused).even(x - 1)
   };
 #eval evenodd('irrelevant).even(20)


### PR DESCRIPTION
Admittedly examples like `evenodd('irrelevant).even(3)` and `#eval evenodd('irrelevant).odd(2)` aren't the point of this example, but it's a bit distracting that they don't work