### PR TITLE
Add space to rendering of `let`, so that recursive decls get rendered as `let rec` as opposed to `letrec`

### DIFF
--- a/src/Simala/Expr/Render.hs
+++ b/src/Simala/Expr/Render.hs
@@ -46,7 +46,7 @@ instance Render Expr where
   renderAtPrio _ (Record r)         = renderRow " = " r
   renderAtPrio p (Project e n)      = parensIf (p > 9) (renderAtPrio 9 e <> "." <> render n)
   renderAtPrio p (Fun t args e)     = parensIf (p > 0) ("fun" <> renderTransparency t <> " " <> renderArgs args <> " => " <> render e)
-  renderAtPrio p (Let d e)          = parensIf (p > 0) ("let" <> renderAtPrio 0 d <> " in " <> render e)
+  renderAtPrio p (Let d e)          = parensIf (p > 0) ("let " <> renderAtPrio 0 d <> " in " <> render e)
   renderAtPrio p (App e es)         = parensIf (p > 9) (renderAtPrio 9 e <> renderArgs es)
   renderAtPrio _ Undefined          = "undefined"
 


### PR DESCRIPTION
I'm not sure if this is _the best_ way to fix the problem I encountered when compiling Lam4 to Simala), but it seems to at least be *a* way, and a simple one at that (changing `letrec` to `let rec` in the compiled code got it to parse).

In case you are curious, the problem I ran into was

```
generated/simala/output.simala:11:254:
   |
11 | rec bleh_26 = fun (relationship_33,attributeSelector_34,condition_35) => if uncertain_7(relationship_33) then 0.0 else let opaque kept_29 = filter_21(condition_35,relationship_33) in let opaque numbers_30 = map_16(attributeSelector_34,kept_29) in letrec toVal_31 = fun (x_32) => if condition_35(x_32) ~= true then attributeSelector_34(x_32) else 0.0 in foldr(fun (x_27,r_28) => toVal_31(x_27) + r_28,0.0,relationship_33) ;
   |                                                                                                                                                                                                                                                              ^
expecting "false", "fun", "if", "let", "true", "undefined", or identifier
```